### PR TITLE
Fixed overflow issue on message bubble

### DIFF
--- a/lib/src/widgets/message/message.dart
+++ b/lib/src/widgets/message/message.dart
@@ -530,6 +530,8 @@ class Message extends StatelessWidget {
                 showName: showName,
                 usePreviewData: usePreviewData,
                 userAgent: userAgent,
+                useWidgetWrap: true,
+                widgetWrapWidthExtent: messageWidth.toDouble() * 0.6,
                 showUserNameForRepliedMessage: showUserNameForRepliedMessage,
               );
       case types.MessageType.video:


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/flyerhq/flutter_chat_ui/blob/main/CONTRIBUTING.md
-->

### What does it do?

Long messages clip off the message bubble and will not wrap if it goes beyond the visible area. The solution introduced breaks down the message into an array of strings (lines) based on the bubble width to which an array of Text widgets are derived and laid out in a Column widget. In effect renders the long message as wrapped text. 

### Why is it needed?

This solution is needed since Text widget's soft wrap does not solve the issue encountered in this implementation.

### How to test it?

Input a very long message.

### Related issues/PRs

Let us know if this is related to any issue/pull request.
